### PR TITLE
Fixes #26: [Fleet Execution] Complete REST Client API Coverage & Type Hints

### DIFF
--- a/src/jules/client.py
+++ b/src/jules/client.py
@@ -1,3 +1,4 @@
+"""Jules REST API Client."""
 import os
 import httpx
 from typing import Iterator, Optional, Dict, Any
@@ -5,6 +6,9 @@ from .models import Session, Activity, Source
 
 class JulesError(Exception):
     pass
+
+class JulesAPIError(JulesError):
+    """Exception raised for API errors."""
 
 class JulesClient:
     def __init__(self, api_key: Optional[str] = None):
@@ -17,10 +21,10 @@ class JulesClient:
             headers={"x-goog-api-key": self.api_key}
         )
 
-    def __enter__(self):
+    def __enter__(self) -> "JulesClient":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self._client.close()
 
     def create_session(self, prompt: str) -> Session:
@@ -72,6 +76,28 @@ class JulesClient:
 
             for activity_data in data.get("activities", []):
                 yield Activity.from_dict(activity_data)
+
+            next_page_token = data.get("nextPageToken")
+            if not next_page_token:
+                break
+
+    def approve_plan(self, name: str) -> None:
+        response = self._client.post(f"/{name}:approvePlan")
+        response.raise_for_status()
+
+    def list_sources(self) -> Iterator[Source]:
+        next_page_token = None
+        while True:
+            params: Dict[str, Any] = {}
+            if next_page_token:
+                params["pageToken"] = next_page_token
+
+            response = self._client.get("/sources", params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            for source_data in data.get("sources", []):
+                yield Source.from_dict(source_data)
 
             next_page_token = data.get("nextPageToken")
             if not next_page_token:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -70,3 +70,27 @@ def test_empty_results(client, mock_api):
     mock_api.get("/sessions").mock(return_value=Response(200, json={}))
     sessions = list(client.list_sessions())
     assert len(sessions) == 0
+
+def test_approve_plan(client, mock_api):
+    mock_api.post("/sessions/123:approvePlan").mock(return_value=Response(200, json={}))
+    client.approve_plan("sessions/123")
+
+def test_list_sources_pagination(client, mock_api):
+    def side_effect(request):
+        params = request.url.params
+        if "pageToken" not in params:
+             return Response(200, json={
+                "sources": [{"name": "sources/1", "uri": "https://example.com/1", "type": "TYPE_X"}],
+                "nextPageToken": "page2"
+            })
+        elif params["pageToken"] == "page2":
+             return Response(200, json={
+                "sources": [{"name": "sources/2", "uri": "https://example.com/2", "type": "TYPE_Y"}],
+            })
+        return Response(404)
+
+    mock_api.get("/sources").mock(side_effect=side_effect)
+    sources = list(client.list_sources())
+    assert len(sources) == 2
+    assert sources[0].name == "sources/1"
+    assert sources[1].name == "sources/2"


### PR DESCRIPTION
Fixes #26

This PR completes the REST Client API coverage by adding missing methods `approve_plan` and `list_sources`. It also adds proper error handling types by introducing `JulesAPIError`, and provides type annotations to the `__enter__` and `__exit__` context manager methods as well as a module docstring to resolve strict `mypy` issues. Appropriate tests for the new methods are also included.

---
*PR created automatically by Jules for task [13286607194214781494](https://jules.google.com/task/13286607194214781494) started by @davideast*