### PR TITLE
Fixes #24: [Fleet Execution] Implement remaining missing API Data Models and client methods

### DIFF
--- a/src/jules/client.py
+++ b/src/jules/client.py
@@ -63,6 +63,11 @@ class JulesClient:
         response = self._client.post(f"/{session_name}:sendMessage", json={"message": message})
         response.raise_for_status()
 
+    def get_activity(self, name: str) -> Activity:
+        response = self._client.get(f"/{name}")
+        response.raise_for_status()
+        return Activity.from_dict(response.json())
+
     def list_activities(self, session_name: str) -> Iterator[Activity]:
         next_page_token = None
         while True:
@@ -84,6 +89,19 @@ class JulesClient:
     def approve_plan(self, name: str) -> None:
         response = self._client.post(f"/{name}:approvePlan")
         response.raise_for_status()
+
+    def archive_session(self, name: str) -> None:
+        response = self._client.post(f"/{name}:archiveSession")
+        response.raise_for_status()
+
+    def unarchive_session(self, name: str) -> None:
+        response = self._client.post(f"/{name}:unarchiveSession")
+        response.raise_for_status()
+
+    def get_source(self, name: str) -> Source:
+        response = self._client.get(f"/{name}")
+        response.raise_for_status()
+        return Source.from_dict(response.json())
 
     def list_sources(self) -> Iterator[Source]:
         next_page_token = None

--- a/src/jules/models.py
+++ b/src/jules/models.py
@@ -15,6 +15,15 @@ class SessionState(str, Enum):
     FAILED = "FAILED"
     CANCELLED = "CANCELLED"
 
+class ActivityType(str, Enum):
+    AGENT_MESSAGED = "agentMessaged"
+    USER_MESSAGED = "userMessaged"
+    PLAN_GENERATED = "planGenerated"
+    PLAN_APPROVED = "planApproved"
+    PROGRESS_UPDATED = "progressUpdated"
+    SESSION_COMPLETED = "sessionCompleted"
+    SESSION_FAILED = "sessionFailed"
+
 @dataclass
 class Session:
     name: str
@@ -66,46 +75,106 @@ class Session:
 class Activity:
     name: str
     create_time: str
-    type: str
+    type: ActivityType
     details: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Activity":
+        # Identify the activity type from the keys
+        # The actual API returns one-of fields, e.g. "userMessaged": {...}
+        # The synthetic type will correspond to the one-of field present.
+        details: Dict[str, Any] = {}
+        activity_type = ActivityType.AGENT_MESSAGED  # fallback, should ideally not happen if enum covers all
+
+        # We need to look for any of the known one-of fields
+        # Note: If memory states that ActivityType is not explicitly defined in the discovery doc
+        # (which uses one-of properties) and requires a custom synthetic enum in the Python SDK
+        # for idiomatic usage (e.g., AGENT_MESSAGED, USER_MESSAGED), we implement that logic here.
+        for t in ActivityType:
+            if t.value in data:
+                activity_type = t
+                details = data[t.value]
+                break
+
         return cls(
             name=data["name"],
             create_time=data["createTime"],
-            type=data["type"],
-            details=data.get("details", {}),
+            type=activity_type,
+            details=details,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "name": self.name,
+            "createTime": self.create_time,
+        }
+        result[self.type.value] = self.details
+        return result
+
+@dataclass
+class GitHubBranch:
+    display_name: str
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GitHubBranch":
+        return cls(
+            display_name=data["displayName"],
         )
 
     def to_dict(self) -> Dict[str, Any]:
         return {
-            "name": self.name,
-            "createTime": self.create_time,
-            "type": self.type,
-            "details": self.details,
+            "displayName": self.display_name,
+        }
+
+@dataclass
+class GitHubRepo:
+    owner: str
+    repo: str
+    is_private: bool
+    default_branch: GitHubBranch
+    branches: List[GitHubBranch]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GitHubRepo":
+        return cls(
+            owner=data.get("owner", ""),
+            repo=data.get("repo", ""),
+            is_private=data.get("isPrivate", False),
+            default_branch=GitHubBranch.from_dict(data["defaultBranch"]) if "defaultBranch" in data else GitHubBranch(""),
+            branches=[GitHubBranch.from_dict(b) for b in data.get("branches", [])],
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "owner": self.owner,
+            "repo": self.repo,
+            "isPrivate": self.is_private,
+            "defaultBranch": self.default_branch.to_dict(),
+            "branches": [b.to_dict() for b in self.branches],
         }
 
 @dataclass
 class Source:
     name: str
-    uri: str
-    type: str
+    id: str
+    github_repo: Optional[GitHubRepo] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Source":
         return cls(
             name=data["name"],
-            uri=data["uri"],
-            type=data["type"],
+            id=data.get("id", ""),
+            github_repo=GitHubRepo.from_dict(data["githubRepo"]) if "githubRepo" in data else None,
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        result: Dict[str, Any] = {
             "name": self.name,
-            "uri": self.uri,
-            "type": self.type,
+            "id": self.id,
         }
+        if self.github_repo:
+            result["githubRepo"] = self.github_repo.to_dict()
+        return result
 
 @dataclass
 class PlanStep:
@@ -152,47 +221,6 @@ class Plan:
             "createTime": self.create_time,
         }
 
-@dataclass
-class GitHubBranch:
-    display_name: str
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GitHubBranch":
-        return cls(
-            display_name=data["displayName"],
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "displayName": self.display_name,
-        }
-
-@dataclass
-class GitHubRepo:
-    owner: str
-    repo: str
-    is_private: bool
-    default_branch: GitHubBranch
-    branches: List[GitHubBranch]
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GitHubRepo":
-        return cls(
-            owner=data.get("owner", ""),
-            repo=data.get("repo", ""),
-            is_private=data.get("isPrivate", False),
-            default_branch=GitHubBranch.from_dict(data["defaultBranch"]) if "defaultBranch" in data else GitHubBranch(""),
-            branches=[GitHubBranch.from_dict(b) for b in data.get("branches", [])],
-        )
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "owner": self.owner,
-            "repo": self.repo,
-            "isPrivate": self.is_private,
-            "defaultBranch": self.default_branch.to_dict(),
-            "branches": [b.to_dict() for b in self.branches],
-        }
 
 @dataclass
 class PullRequest:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -51,15 +51,25 @@ def test_send_message(client, mock_api):
     mock_api.post("/sessions/123:sendMessage").mock(return_value=Response(200, json={}))
     client.send_message("sessions/123", "hello")
 
+def test_get_activity(client, mock_api):
+    mock_api.get("/sessions/123/activities/456").mock(return_value=Response(200, json={
+        "name": "sessions/123/activities/456",
+        "createTime": "t1",
+        "agentMessaged": {"message": "foo"}
+    }))
+    activity = client.get_activity("sessions/123/activities/456")
+    assert activity.name == "sessions/123/activities/456"
+    assert activity.details == {"message": "foo"}
+
 def test_list_activities(client, mock_api):
     mock_api.get("/sessions/123/activities").mock(return_value=Response(200, json={
         "activities": [
-            {"name": "activities/1", "createTime": "t1", "type": "TYPE_A", "details": {"foo": "bar"}}
+            {"name": "activities/1", "createTime": "t1", "userMessaged": {"message": "bar"}}
         ]
     }))
     activities = list(client.list_activities("sessions/123"))
     assert len(activities) == 1
-    assert activities[0].details == {"foo": "bar"}
+    assert activities[0].details == {"message": "bar"}
 
 def test_error_handling_404(client, mock_api):
     mock_api.get("/sessions/999").mock(return_value=Response(404))
@@ -75,17 +85,34 @@ def test_approve_plan(client, mock_api):
     mock_api.post("/sessions/123:approvePlan").mock(return_value=Response(200, json={}))
     client.approve_plan("sessions/123")
 
+def test_archive_session(client, mock_api):
+    mock_api.post("/sessions/123:archiveSession").mock(return_value=Response(200, json={}))
+    client.archive_session("sessions/123")
+
+def test_unarchive_session(client, mock_api):
+    mock_api.post("/sessions/123:unarchiveSession").mock(return_value=Response(200, json={}))
+    client.unarchive_session("sessions/123")
+
+def test_get_source(client, mock_api):
+    mock_api.get("/sources/1").mock(return_value=Response(200, json={
+        "name": "sources/1",
+        "id": "1",
+    }))
+    source = client.get_source("sources/1")
+    assert source.name == "sources/1"
+    assert source.id == "1"
+
 def test_list_sources_pagination(client, mock_api):
     def side_effect(request):
         params = request.url.params
         if "pageToken" not in params:
              return Response(200, json={
-                "sources": [{"name": "sources/1", "uri": "https://example.com/1", "type": "TYPE_X"}],
+                "sources": [{"name": "sources/1", "id": "1"}],
                 "nextPageToken": "page2"
             })
         elif params["pageToken"] == "page2":
              return Response(200, json={
-                "sources": [{"name": "sources/2", "uri": "https://example.com/2", "type": "TYPE_Y"}],
+                "sources": [{"name": "sources/2", "id": "2"}],
             })
         return Response(404)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,16 +25,44 @@ def test_session_to_dict():
     assert d["state"] == "RUNNING"
 
 def test_activity_roundtrip():
-    data = {"name": "activities/1", "createTime": "t", "type": "TYPE_A", "details": {"foo": "bar"}}
+    data = {
+        "name": "activities/1",
+        "createTime": "t",
+        "agentMessaged": {"message": "hello world"}
+    }
     a = Activity.from_dict(data)
-    assert a.details == {"foo": "bar"}
-    assert a.to_dict()["type"] == "TYPE_A"
+    assert a.details == {"message": "hello world"}
+    assert a.type.value == "agentMessaged"
+
+    roundtrip = a.to_dict()
+    assert roundtrip["name"] == "activities/1"
+    assert roundtrip["createTime"] == "t"
+    assert "agentMessaged" in roundtrip
+    assert roundtrip["agentMessaged"] == {"message": "hello world"}
 
 def test_source_roundtrip():
-    data = {"name": "sources/1", "uri": "https://github.com/x/y", "type": "GITHUB"}
+    data = {
+        "name": "sources/1",
+        "id": "1",
+        "githubRepo": {
+            "owner": "test",
+            "repo": "repo",
+            "isPrivate": True,
+            "defaultBranch": {"displayName": "main"},
+            "branches": [{"displayName": "main"}]
+        }
+    }
     s = Source.from_dict(data)
-    assert s.uri == "https://github.com/x/y"
-    assert s.to_dict()["type"] == "GITHUB"
+    assert s.id == "1"
+    assert s.github_repo is not None
+    assert s.github_repo.owner == "test"
+    assert s.github_repo.repo == "repo"
+
+    roundtrip = s.to_dict()
+    assert roundtrip["name"] == "sources/1"
+    assert roundtrip["id"] == "1"
+    assert "githubRepo" in roundtrip
+    assert roundtrip["githubRepo"]["owner"] == "test"
 
 from jules.models import Plan, PlanStep, PullRequest, SessionOutput, AutomationMode
 


### PR DESCRIPTION
Fixes #24

This pull request implements the remaining missing pieces of the Python SDK following the recent merges of PR #29, PR #27, and PR #22. 

- **Models**: Added the `ActivityType` enum and one-of property serialization/deserialization logic to the `Activity` model. Refactored the `Source` model to support `id` and `githubRepo` (`GitHubRepo` type).
- **Client**: Added missing methods: `get_activity`, `get_source`, `archive_session`, and `unarchive_session`.
- **Tests**: Expanded test coverage in `test_models.py` and `test_client.py` for the new client methods and correctly modified existing test models to accommodate the updated schema definitions.

All `pytest` tests pass, and `mypy` typechecking succeeds. No regressions were introduced, and previously submitted overlapping functionality has been properly skipped to avoid duplication.

---
*PR created automatically by Jules for task [14317075273236002576](https://jules.google.com/task/14317075273236002576) started by @davideast*