### PR TITLE
Fixes #36: Refactor JulesClient Base URL Configuration

### DIFF
--- a/src/jules/client.py
+++ b/src/jules/client.py
@@ -11,11 +11,11 @@ class JulesAPIError(JulesError):
     """Exception raised for API errors."""
 
 class JulesClient:
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(self, api_key: Optional[str] = None, base_url: str = "https://jules.googleapis.com/v1alpha"):
         self.api_key = api_key or os.environ.get("JULES_API_KEY")
         if not self.api_key:
             raise JulesError("API key must be provided or set in JULES_API_KEY environment variable")
-        self.base_url = "https://jules.googleapis.com/v1alpha"
+        self.base_url = base_url
         self._client = httpx.Client(
             base_url=self.base_url,
             headers={"x-goog-api-key": self.api_key}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,17 @@
 import pytest
 import httpx
 from httpx import Response
+from jules.client import JulesClient
 from jules.models import SessionState
+
+def test_default_base_url():
+    client = JulesClient(api_key="test-key")
+    assert client.base_url == "https://jules.googleapis.com/v1alpha"
+
+def test_custom_base_url():
+    client = JulesClient(api_key="test-key", base_url="http://localhost:8080")
+    assert client.base_url == "http://localhost:8080"
+
 
 def test_create_session(client, mock_api):
     mock_api.post("/sessions").mock(return_value=Response(200, json={


### PR DESCRIPTION
Fixes #36

This PR refactors the `JulesClient` to allow configuration of the API base URL via the `base_url` parameter during instantiation, rather than hardcoding it. This enables tests against staging environments and mocking.

### Changes:
- **`src/jules/client.py`:** Modified `JulesClient.__init__` to accept `base_url: str` with the default value of `"https://jules.googleapis.com/v1alpha"`.
- **`tests/test_client.py`:** Added `test_default_base_url` and `test_custom_base_url` to verify the default and custom configurations.

---
*PR created automatically by Jules for task [7277494239925730948](https://jules.google.com/task/7277494239925730948) started by @davideast*

---
⚠️ Closed by fleet-merge: merge conflict detected. Task re-dispatched.