### PR TITLE
Fixes #43: Achieve 100% test coverage for Python SDK

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,35 @@
 import pytest
 import httpx
 from httpx import Response
+from jules.client import JulesClient, JulesError
 from jules.models import SessionState
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("JULES_API_KEY", raising=False)
+    with pytest.raises(JulesError):
+        JulesClient(api_key=None)
+
+def test_context_manager():
+    with JulesClient(api_key="test") as client:
+        assert client.api_key == "test"
+
+def test_list_activities_pagination(client, mock_api):
+    def side_effect(request):
+        params = request.url.params
+        if "pageToken" not in params:
+             return Response(200, json={
+                "activities": [{"name": "activities/1", "createTime": "t1", "userMessaged": {"message": "bar"}}],
+                "nextPageToken": "page2"
+            })
+        elif params["pageToken"] == "page2":
+             return Response(200, json={
+                "activities": [{"name": "activities/2", "createTime": "t2", "agentMessaged": {"message": "baz"}}],
+            })
+        return Response(404)
+
+    mock_api.get("/sessions/123/activities").mock(side_effect=side_effect)
+    activities = list(client.list_activities("sessions/123"))
+    assert len(activities) == 2
 
 def test_create_session(client, mock_api):
     mock_api.post("/sessions").mock(return_value=Response(200, json={

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,4 @@
-from jules.models import Session, Activity, Source, SessionState
+from jules.models import Session, Activity, Source, SessionState, Plan, PlanStep, PullRequest, SessionOutput, AutomationMode, ActivityType, GitPatch, ChangeSet
 
 def test_session_from_dict():
     data = {
@@ -63,8 +63,6 @@ def test_source_roundtrip():
     assert roundtrip["id"] == "1"
     assert "githubRepo" in roundtrip
     assert roundtrip["githubRepo"]["owner"] == "test"
-
-from jules.models import Plan, PlanStep, PullRequest, SessionOutput, AutomationMode
 
 def test_plan_roundtrip():
     data = {
@@ -139,3 +137,80 @@ def test_session_outputs():
     assert len(roundtrip["outputs"]) == 1
     assert roundtrip["outputs"][0]["pullRequest"]["url"] == "https://github.com/owner/repo/pull/1"
     assert roundtrip["archived"] is True
+
+def test_session_optional_fields_to_dict():
+    session = Session(
+        name="sessions/1",
+        state=SessionState.RUNNING,
+        create_time="t1",
+        update_time="t2",
+        expire_time="t3",
+        prompt="hello",
+        url="http://example.com"
+    )
+    d = session.to_dict()
+    assert d["expireTime"] == "t3"
+    assert d["prompt"] == "hello"
+    assert d["url"] == "http://example.com"
+
+def test_activity_unknown_type():
+    data = {
+        "name": "activities/1",
+        "createTime": "t",
+        "someUnknownField": {"message": "hello world"}
+    }
+    a = Activity.from_dict(data)
+    # the fallback in models.py is AGENT_MESSAGED
+    assert a.type == ActivityType.AGENT_MESSAGED
+    assert a.details == {}
+
+def test_git_patch_roundtrip():
+    data = {
+        "unidiffPatch": "patch",
+        "baseCommitId": "123",
+        "suggestedCommitMessage": "msg"
+    }
+    gp = GitPatch.from_dict(data)
+    assert gp.unidiff_patch == "patch"
+    assert gp.base_commit_id == "123"
+    assert gp.suggested_commit_message == "msg"
+
+    d = gp.to_dict()
+    assert d["unidiffPatch"] == "patch"
+    assert d["baseCommitId"] == "123"
+    assert d["suggestedCommitMessage"] == "msg"
+
+def test_change_set_roundtrip():
+    data = {
+        "gitPatch": {
+            "unidiffPatch": "patch",
+            "baseCommitId": "123",
+            "suggestedCommitMessage": "msg"
+        },
+        "source": "source1"
+    }
+    cs = ChangeSet.from_dict(data)
+    assert cs.source == "source1"
+    assert cs.git_patch.unidiff_patch == "patch"
+
+    d = cs.to_dict()
+    assert d["source"] == "source1"
+    assert d["gitPatch"]["unidiffPatch"] == "patch"
+
+def test_session_output_change_set():
+    data = {
+        "changeSet": {
+            "gitPatch": {
+                "unidiffPatch": "patch",
+                "baseCommitId": "123",
+                "suggestedCommitMessage": "msg"
+            },
+            "source": "source1"
+        }
+    }
+    so = SessionOutput.from_dict(data)
+    assert so.change_set is not None
+    assert so.change_set.source == "source1"
+
+    d = so.to_dict()
+    assert d["changeSet"]["source"] == "source1"


### PR DESCRIPTION
Fixes #43

Adds missing test cases to `tests/test_client.py` for client error paths and context managers.
Adds missing test cases to `tests/test_models.py` for model optional field properties and fallback handling for models.
Achieves 100% code coverage for the `src/jules` codebase.

---
*PR created automatically by Jules for task [6694208545400328378](https://jules.google.com/task/6694208545400328378) started by @davideast*

---
⚠️ Closed by fleet-merge: merge conflict detected. Task re-dispatched.