### PR TITLE
Fixes #37: Implement JulesAPIError for Error Handling

### DIFF
--- a/src/jules/client.py
+++ b/src/jules/client.py
@@ -9,8 +9,20 @@ class JulesError(Exception):
 
 class JulesAPIError(JulesError):
     """Exception raised for API errors."""
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
 
 class JulesClient:
+    def _raise_for_status(self, response: httpx.Response) -> None:
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise JulesAPIError(
+                f"API Error {e.response.status_code}: {e.response.text}",
+                e.response.status_code
+            ) from e
+
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or os.environ.get("JULES_API_KEY")
         if not self.api_key:
@@ -29,12 +41,12 @@ class JulesClient:
 
     def create_session(self, prompt: str) -> Session:
         response = self._client.post("/sessions", json={"prompt": prompt})
-        response.raise_for_status()
+        self._raise_for_status(response)
         return Session.from_dict(response.json())
 
     def get_session(self, name: str) -> Session:
         response = self._client.get(f"/{name}")
-        response.raise_for_status()
+        self._raise_for_status(response)
         return Session.from_dict(response.json())
 
     def list_sessions(self) -> Iterator[Session]:
@@ -45,7 +57,7 @@ class JulesClient:
                 params["pageToken"] = next_page_token
 
             response = self._client.get("/sessions", params=params)
-            response.raise_for_status()
+            self._raise_for_status(response)
             data = response.json()
 
             for session_data in data.get("sessions", []):
@@ -57,15 +69,15 @@ class JulesClient:
 
     def delete_session(self, name: str) -> None:
         response = self._client.delete(f"/{name}")
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def send_message(self, session_name: str, message: str) -> None:
         response = self._client.post(f"/{session_name}:sendMessage", json={"message": message})
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def get_activity(self, name: str) -> Activity:
         response = self._client.get(f"/{name}")
-        response.raise_for_status()
+        self._raise_for_status(response)
         return Activity.from_dict(response.json())
 
     def list_activities(self, session_name: str) -> Iterator[Activity]:
@@ -76,7 +88,7 @@ class JulesClient:
                 params["pageToken"] = next_page_token
 
             response = self._client.get(f"/{session_name}/activities", params=params)
-            response.raise_for_status()
+            self._raise_for_status(response)
             data = response.json()
 
             for activity_data in data.get("activities", []):
@@ -88,19 +100,19 @@ class JulesClient:
 
     def approve_plan(self, name: str) -> None:
         response = self._client.post(f"/{name}:approvePlan")
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def archive_session(self, name: str) -> None:
         response = self._client.post(f"/{name}:archiveSession")
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def unarchive_session(self, name: str) -> None:
         response = self._client.post(f"/{name}:unarchiveSession")
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def get_source(self, name: str) -> Source:
         response = self._client.get(f"/{name}")
-        response.raise_for_status()
+        self._raise_for_status(response)
         return Source.from_dict(response.json())
 
     def list_sources(self) -> Iterator[Source]:
@@ -111,7 +123,7 @@ class JulesClient:
                 params["pageToken"] = next_page_token
 
             response = self._client.get("/sources", params=params)
-            response.raise_for_status()
+            self._raise_for_status(response)
             data = response.json()
 
             for source_data in data.get("sources", []):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ import pytest
 import httpx
 from httpx import Response
 from jules.models import SessionState
+from jules.client import JulesAPIError
 
 def test_create_session(client, mock_api):
     mock_api.post("/sessions").mock(return_value=Response(200, json={
@@ -72,9 +73,13 @@ def test_list_activities(client, mock_api):
     assert activities[0].details == {"message": "bar"}
 
 def test_error_handling_404(client, mock_api):
-    mock_api.get("/sessions/999").mock(return_value=Response(404))
-    with pytest.raises(httpx.HTTPStatusError):
+    mock_api.get("/sessions/999").mock(return_value=Response(404, text="Not Found"))
+    with pytest.raises(JulesAPIError) as exc_info:
         client.get_session("sessions/999")
+
+    assert exc_info.value.status_code == 404
+    assert "API Error 404" in str(exc_info.value)
+    assert "Not Found" in str(exc_info.value)
 
 def test_empty_results(client, mock_api):
     mock_api.get("/sessions").mock(return_value=Response(200, json={}))


### PR DESCRIPTION
Fixes #37

Implements `JulesAPIError` wrapping for HTTP errors generated by the API to ensure uniform error handling.
Introduced `_raise_for_status(response: httpx.Response)` helper method in `JulesClient` that catches `httpx.HTTPStatusError` and re-raises it wrapped in `JulesAPIError`. Applied it across all endpoints.

Tests added to verify the wrapping behavior for 404 responses.

---
*PR created automatically by Jules for task [14913135895559671156](https://jules.google.com/task/14913135895559671156) started by @davideast*

---
⚠️ Closed by fleet-merge: merge conflict detected. Task re-dispatched.