### PR TITLE
Fixes #44: Synchronize Domain Models with Latest API Discovery Schema

### DIFF
--- a/src/jules/models.py
+++ b/src/jules/models.py
@@ -25,12 +25,58 @@ class ActivityType(str, Enum):
     SESSION_FAILED = "sessionFailed"
 
 @dataclass
+class GitHubRepoContext:
+    github_repo: 'GitHubRepo'
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GitHubRepoContext":
+        return cls(
+            github_repo=GitHubRepo.from_dict(data["githubRepo"]),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "githubRepo": self.github_repo.to_dict(),
+        }
+
+@dataclass
+class SourceContext:
+    source: str
+    github_repo_context: Optional[GitHubRepoContext] = None
+    working_branch: Optional[str] = None
+    environment_variables_enabled: Optional[bool] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SourceContext":
+        return cls(
+            source=data["source"],
+            github_repo_context=GitHubRepoContext.from_dict(data["githubRepoContext"]) if "githubRepoContext" in data else None,
+            working_branch=data.get("workingBranch"),
+            environment_variables_enabled=data.get("environmentVariablesEnabled"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "source": self.source,
+        }
+        if self.github_repo_context:
+            result["githubRepoContext"] = self.github_repo_context.to_dict()
+        if self.working_branch:
+            result["workingBranch"] = self.working_branch
+        if self.environment_variables_enabled is not None:
+            result["environmentVariablesEnabled"] = self.environment_variables_enabled
+        return result
+
+@dataclass
 class Session:
     name: str
     state: SessionState
     create_time: str
     update_time: str
-    expire_time: Optional[str] = None
+    id: str = ""
+    title: Optional[str] = None
+    require_plan_approval: Optional[bool] = None
+    source_context: Optional['SourceContext'] = None
     prompt: Optional[str] = None
     automation_mode: AutomationMode = AutomationMode.AUTOMATION_MODE_UNSPECIFIED
     outputs: List['SessionOutput'] = field(default_factory=list)
@@ -44,7 +90,10 @@ class Session:
             state=SessionState(data.get("state", "STATE_UNSPECIFIED")),
             create_time=data["createTime"],
             update_time=data["updateTime"],
-            expire_time=data.get("expireTime"),
+            id=data.get("id", ""),
+            title=data.get("title"),
+            require_plan_approval=data.get("requirePlanApproval"),
+            source_context=SourceContext.from_dict(data["sourceContext"]) if "sourceContext" in data else None,
             prompt=data.get("prompt"),
             automation_mode=AutomationMode(data.get("automationMode", "AUTOMATION_MODE_UNSPECIFIED")),
             outputs=[SessionOutput.from_dict(o) for o in data.get("outputs", [])],
@@ -62,8 +111,14 @@ class Session:
             "outputs": [o.to_dict() for o in self.outputs],
             "archived": self.archived,
         }
-        if self.expire_time:
-            result["expireTime"] = self.expire_time
+        if self.id:
+            result["id"] = self.id
+        if self.title:
+            result["title"] = self.title
+        if self.require_plan_approval is not None:
+            result["requirePlanApproval"] = self.require_plan_approval
+        if self.source_context:
+            result["sourceContext"] = self.source_context.to_dict()
         if self.prompt:
             result["prompt"] = self.prompt
         if self.url:
@@ -76,6 +131,10 @@ class Activity:
     name: str
     create_time: str
     type: ActivityType
+    id: str = ""
+    description: Optional[str] = None
+    originator: Optional[str] = None
+    artifacts: List[Any] = field(default_factory=list)
     details: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -100,6 +159,10 @@ class Activity:
             name=data["name"],
             create_time=data["createTime"],
             type=activity_type,
+            id=data.get("id", ""),
+            description=data.get("description"),
+            originator=data.get("originator"),
+            artifacts=data.get("artifacts", []),
             details=details,
         )
 
@@ -108,6 +171,15 @@ class Activity:
             "name": self.name,
             "createTime": self.create_time,
         }
+        if self.id:
+            result["id"] = self.id
+        if self.description:
+            result["description"] = self.description
+        if self.originator:
+            result["originator"] = self.originator
+        if self.artifacts:
+            result["artifacts"] = self.artifacts
+
         result[self.type.value] = self.details
         return result
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,11 +7,37 @@ def test_session_from_dict():
         "createTime": "2023-01-01T00:00:00Z",
         "updateTime": "2023-01-01T00:00:00Z",
         "prompt": "hello",
+        "id": "123",
+        "title": "My Session",
+        "requirePlanApproval": True,
+        "sourceContext": {
+            "source": "sources/1",
+            "githubRepoContext": {
+                "githubRepo": {
+                    "owner": "test",
+                    "repo": "repo",
+                    "isPrivate": True,
+                    "defaultBranch": {"displayName": "main"},
+                    "branches": [{"displayName": "main"}]
+                }
+            },
+            "workingBranch": "main",
+            "environmentVariablesEnabled": True
+        }
     }
     session = Session.from_dict(data)
     assert session.name == "sessions/123"
     assert session.state == SessionState.CREATED
     assert session.prompt == "hello"
+    assert session.id == "123"
+    assert session.title == "My Session"
+    assert session.require_plan_approval is True
+    assert session.source_context is not None
+    assert session.source_context.source == "sources/1"
+    assert session.source_context.github_repo_context is not None
+    assert session.source_context.github_repo_context.github_repo.owner == "test"
+    assert session.source_context.working_branch == "main"
+    assert session.source_context.environment_variables_enabled is True
 
 def test_session_to_dict():
     session = Session(
@@ -23,22 +49,36 @@ def test_session_to_dict():
     d = session.to_dict()
     assert d["name"] == "sessions/1"
     assert d["state"] == "RUNNING"
+    assert "expireTime" not in d
 
 def test_activity_roundtrip():
     data = {
         "name": "activities/1",
         "createTime": "t",
-        "agentMessaged": {"message": "hello world"}
+        "agentMessaged": {"message": "hello world"},
+        "id": "activity_1",
+        "description": "Agent sent a message",
+        "originator": "agent",
+        "artifacts": [{"id": "artifact_1", "type": "code"}]
     }
     a = Activity.from_dict(data)
     assert a.details == {"message": "hello world"}
     assert a.type.value == "agentMessaged"
+    assert a.id == "activity_1"
+    assert a.description == "Agent sent a message"
+    assert a.originator == "agent"
+    assert len(a.artifacts) == 1
+    assert a.artifacts[0]["id"] == "artifact_1"
 
     roundtrip = a.to_dict()
     assert roundtrip["name"] == "activities/1"
     assert roundtrip["createTime"] == "t"
     assert "agentMessaged" in roundtrip
     assert roundtrip["agentMessaged"] == {"message": "hello world"}
+    assert roundtrip["id"] == "activity_1"
+    assert roundtrip["description"] == "Agent sent a message"
+    assert roundtrip["originator"] == "agent"
+    assert roundtrip["artifacts"][0]["id"] == "artifact_1"
 
 def test_source_roundtrip():
     data = {


### PR DESCRIPTION
Fixes #44

This PR updates the Python SDK domain models (`Session` and `Activity`) to align with the current Jules API discovery document schema.

Changes include:
* Added `GitHubRepoContext` and `SourceContext` dataclasses.
* Updated `Session` to add `id`, `title`, `require_plan_approval`, and `source_context` fields, and removed the `expire_time` field.
* Updated `Activity` to add `id`, `description`, `originator`, and `artifacts` fields.
* Updated `from_dict` and `to_dict` methods for these dataclasses accordingly.
* Added tests for `Session` and `Activity` to verify the schema changes and removed references to `expireTime`.

---
*PR created automatically by Jules for task [12734837190210144403](https://jules.google.com/task/12734837190210144403) started by @davideast*

---
⚠️ Closed by fleet-merge: merge conflict detected. Task re-dispatched.