### PR TITLE
Fixes #38: Add insight documentation for test coverage

### DIFF
--- a/.fleet/insight_38.md
+++ b/.fleet/insight_38.md
@@ -1,0 +1,7 @@
+# Insight #38: Python SDK Test Coverage Metrics
+
+The Python SDK for the Jules API currently has 95% total code coverage. While this is a high percentage, there are missing execution paths in conditional edge-case branches and exception flows, notably:
+1. `src/jules/client.py`: Lines 17 (missing API key error), 25/28 (context manager flows), 76 (activity type enumeration mapping).
+2. `src/jules/models.py`: Defensive deserialization paths where API dictionaries omit expected keys.
+
+An assessment issue (#45) has been generated to implement the missing unit tests and target 100% test coverage.


### PR DESCRIPTION
This PR adds the documentation for the test coverage insight. No code changes were necessary. An assessment issue has been created to track the work to achieve 100% code coverage.

Fixes #38

---
*PR created automatically by Jules for task [2808563993169573831](https://jules.google.com/task/2808563993169573831) started by @davideast*

---
⚠️ Closed by fleet-merge: merge conflict detected. Task re-dispatched.