### PR TITLE
chore: update fleet-merge workflow for --redispatch flag rename

### DIFF
--- a/.github/workflows/fleet-merge.yml
+++ b/.github/workflows/fleet-merge.yml
@@ -19,8 +19,8 @@ on:
         description: 'Fleet run ID (required for fleet-run mode)'
         type: string
         default: ''
-      re_dispatch:
-        description: 'Auto re-dispatch on merge conflict'
+      redispatch:
+        description: 'Enable smart conflict resolution'
         type: boolean
         default: true
 
@@ -42,8 +42,8 @@ jobs:
           node-version: '22'
       - run: |
           REDISPATCH_FLAG=""
-          if [ "${{ inputs.re_dispatch }}" = "true" ]; then
-            REDISPATCH_FLAG="--re-dispatch"
+          if [ "${{ inputs.redispatch }}" = "true" ]; then
+            REDISPATCH_FLAG="--redispatch"
           fi
           npx @google/jules-fleet merge \
             --mode ${{ inputs.mode || 'label' }} \


### PR DESCRIPTION
Updates `fleet-merge.yml` for `@google/jules-fleet@0.0.1-experimental.15`:
- Renames `re_dispatch` input → `redispatch`
- Renames `--re-dispatch` CLI flag → `--redispatch`
- Updates description to "Enable smart conflict resolution"