### PR TITLE
Resolve PR #59 conflicts, introduce `JulesAPIError` wrapping

### DIFF
--- a/src/jules/client.py
+++ b/src/jules/client.py
@@ -9,8 +9,20 @@ class JulesError(Exception):
 
 class JulesAPIError(JulesError):
     """Exception raised for API errors."""
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
 
 class JulesClient:
+    def _raise_for_status(self, response: httpx.Response) -> None:
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise JulesAPIError(
+                f"API Error {e.response.status_code}: {e.response.text}",
+                e.response.status_code
+            ) from e
+
     def __init__(self, api_key: Optional[str] = None, base_url: str = "https://jules.googleapis.com/v1alpha"):
         self.api_key = api_key or os.environ.get("JULES_API_KEY")
         if not self.api_key:
@@ -35,7 +47,7 @@ class JulesClient:
                 params["pageToken"] = next_page_token
 
             response = self._client.get(endpoint, params=params)
-            response.raise_for_status()
+            self._raise_for_status(response)
             data = response.json()
 
             for item_data in data.get(key, []):
@@ -47,12 +59,12 @@ class JulesClient:
 
     def create_session(self, prompt: str) -> Session:
         response = self._client.post("/sessions", json={"prompt": prompt})
-        response.raise_for_status()
+        self._raise_for_status(response)
         return Session.from_dict(response.json())
 
     def get_session(self, name: str) -> Session:
         response = self._client.get(f"/{name}")
-        response.raise_for_status()
+        self._raise_for_status(response)
         return Session.from_dict(response.json())
 
     def list_sessions(self) -> Iterator[Session]:
@@ -60,15 +72,15 @@ class JulesClient:
 
     def delete_session(self, name: str) -> None:
         response = self._client.delete(f"/{name}")
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def send_message(self, session_name: str, message: str) -> None:
         response = self._client.post(f"/{session_name}:sendMessage", json={"message": message})
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def get_activity(self, name: str) -> Activity:
         response = self._client.get(f"/{name}")
-        response.raise_for_status()
+        self._raise_for_status(response)
         return Activity.from_dict(response.json())
 
     def list_activities(self, session_name: str) -> Iterator[Activity]:
@@ -76,19 +88,19 @@ class JulesClient:
 
     def approve_plan(self, name: str) -> None:
         response = self._client.post(f"/{name}:approvePlan")
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def archive_session(self, name: str) -> None:
         response = self._client.post(f"/{name}:archiveSession")
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def unarchive_session(self, name: str) -> None:
         response = self._client.post(f"/{name}:unarchiveSession")
-        response.raise_for_status()
+        self._raise_for_status(response)
 
     def get_source(self, name: str) -> Source:
         response = self._client.get(f"/{name}")
-        response.raise_for_status()
+        self._raise_for_status(response)
         return Source.from_dict(response.json())
 
     def list_sources(self) -> Iterator[Source]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 import pytest
 import httpx
 from httpx import Response
-from jules.client import JulesClient, JulesError
+from jules.client import JulesClient, JulesError, JulesAPIError
 from jules.models import SessionState
 
 def test_missing_api_key(monkeypatch):
@@ -108,9 +108,13 @@ def test_list_activities(client, mock_api):
     assert activities[0].details == {"message": "bar"}
 
 def test_error_handling_404(client, mock_api):
-    mock_api.get("/sessions/999").mock(return_value=Response(404))
-    with pytest.raises(httpx.HTTPStatusError):
+    mock_api.get("/sessions/999").mock(return_value=Response(404, text="Not Found"))
+    with pytest.raises(JulesAPIError) as exc_info:
         client.get_session("sessions/999")
+
+    assert exc_info.value.status_code == 404
+    assert "API Error 404" in str(exc_info.value)
+    assert "Not Found" in str(exc_info.value)
 
 def test_empty_results(client, mock_api):
     mock_api.get("/sessions").mock(return_value=Response(200, json={}))


### PR DESCRIPTION
This resolves conflicts with recent merges by porting `JulesAPIError` error handling to the `JulesClient`. Specifically, it updates `_raise_for_status` logic to correctly wrap HTTP exceptions dynamically including the paginated resources.

Conflict resolution:
- Extracted `__init__` in `JulesAPIError` to support standard `status_code` capture.
- Introduced `_raise_for_status` catching `httpx.HTTPStatusError` internally.
- Cleanly applied to the centralized `_paginate` method newly introduced by PR #60 instead of duplicating pagination handling.
- Included corresponding test adjustments using `JulesAPIError`.

---
*PR created automatically by Jules for task [7265552665500656839](https://jules.google.com/task/7265552665500656839) started by @davideast*