### PR TITLE
Fixes #65 Fixes #66 - Resolve and unify PR conflicts for SDK features

### DIFF
--- a/examples/getting_started.py
+++ b/examples/getting_started.py
@@ -1,0 +1,47 @@
+"""Getting started with the Jules SDK: Creating and monitoring a session.
+
+Usage:
+    export JULES_API_KEY=your-key
+    python examples/getting_started.py
+"""
+import time
+from jules import JulesClient
+from jules.models import SessionState
+from jules.models import SourceContext, GitHubRepoContext, GitHubRepo, GitHubBranch
+
+def main() -> None:
+    with JulesClient() as client:
+        print("Creating a new Jules session...")
+
+        # Configure source to be the requested repository
+        source_context = SourceContext(
+            source="sources/github/davideast/jules-sdk-python",
+            github_repo_context=GitHubRepoContext(
+                starting_branch="main"
+            )
+        )
+
+        # We also need to add the sourceContext parameter to create_session
+        session = client.create_session(
+            prompt="Write a hello world program in Python",
+            source_context=source_context
+        )
+        print(f"Session created: {session.name} (State: {session.state.value})")
+
+        print("Polling session state until completed or failed...")
+        while True:
+            current_session = client.get_session(session.name)
+            print(f"Current state: {current_session.state.value}")
+
+            if current_session.state in (SessionState.COMPLETED, SessionState.FAILED, SessionState.CANCELLED):
+                print(f"Session finished with state: {current_session.state.value}")
+                break
+
+            time.sleep(2)
+
+        print("Cleaning up session...")
+        client.delete_session(session.name)
+        print("Session deleted.")
+
+if __name__ == "__main__":
+    main()

--- a/examples/plan_review.py
+++ b/examples/plan_review.py
@@ -1,0 +1,33 @@
+"""Interactive plan review workflow using the Jules SDK.
+
+Usage:
+    export JULES_API_KEY=your-key
+    python examples/plan_review.py
+"""
+import time
+from jules import JulesClient
+from jules.models import SessionState
+
+def main() -> None:
+    with JulesClient() as client:
+        print("Creating session requiring plan approval...")
+        session = client.create_session(
+            prompt="Refactor the authentication module",
+            require_plan_approval=True,
+            source="github/davideast/jules-sdk-python"
+        )
+        print(f"Session created: {session.name}")
+
+        print("Simulating plan review... approving plan.")
+        try:
+            client.approve_plan(session.name)
+            print("Plan approved successfully.")
+        except Exception as e:
+            print(f"Failed to approve plan or plan not ready: {e}")
+
+        print("Cleaning up...")
+        client.delete_session(session.name)
+        print("Done.")
+
+if __name__ == "__main__":
+    main()

--- a/src/jules/client.py
+++ b/src/jules/client.py
@@ -57,8 +57,23 @@ class JulesClient:
             if not next_page_token:
                 break
 
-    def create_session(self, prompt: str) -> Session:
-        response = self._client.post("/sessions", json={"prompt": prompt})
+    def create_session(self, prompt: str, require_plan_approval: Optional[bool] = None, source: Optional[str] = None, source_context: Optional[Any] = None) -> Session:
+        payload: Dict[str, Any] = {"prompt": prompt}
+        if require_plan_approval is not None:
+            payload["requirePlanApproval"] = require_plan_approval
+
+        if source_context:
+            payload["sourceContext"] = source_context.to_dict()
+        elif source is not None:
+            # Format the source properly per the API documentation, default to 'sources/' prefix
+            if not source.startswith("sources/"):
+                source = f"sources/{source}"
+            payload["sourceContext"] = {
+                "source": source,
+                "githubRepoContext": {"startingBranch": "main"}
+            }
+
+        response = self._client.post("/sessions", json=payload)
         self._raise_for_status(response)
         return Session.from_dict(response.json())
 

--- a/src/jules/models.py
+++ b/src/jules/models.py
@@ -10,6 +10,7 @@ class AutomationMode(str, Enum):
 class SessionState(str, Enum):
     STATE_UNSPECIFIED = "STATE_UNSPECIFIED"
     CREATED = "CREATED"
+    QUEUED = "QUEUED"
     RUNNING = "RUNNING"
     IN_PROGRESS = "IN_PROGRESS"
     PAUSED = "PAUSED"
@@ -30,17 +31,22 @@ class ActivityType(str, Enum):
 @dataclass
 class GitHubRepoContext:
     github_repo: Optional['GitHubRepo'] = None
+    starting_branch: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "GitHubRepoContext":
         return cls(
             github_repo=GitHubRepo.from_dict(data["githubRepo"]) if data.get("githubRepo") else None,
+            starting_branch=data.get("startingBranch"),
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
-            "githubRepo": self.github_repo.to_dict() if self.github_repo else None,
-        }
+        result: Dict[str, Any] = {}
+        if self.github_repo:
+            result["githubRepo"] = self.github_repo.to_dict()
+        if self.starting_branch:
+            result["startingBranch"] = self.starting_branch
+        return result
 
 @dataclass
 class SourceContext:
@@ -91,8 +97,8 @@ class Session:
         return cls(
             name=data["name"],
             state=SessionState(data.get("state", "STATE_UNSPECIFIED")),
-            create_time=data["createTime"],
-            update_time=data["updateTime"],
+            create_time=data.get("createTime", ""),
+            update_time=data.get("updateTime", ""),
             id=data.get("id", ""),
             title=data.get("title"),
             require_plan_approval=data.get("requirePlanApproval"),


### PR DESCRIPTION
Fixes #65
Fixes #66

This PR fully resolves conflicts between PR #74 and PR #76 by consolidating their implementations. 
- Updates `SessionState` and handles missing fields (`createTime`, `updateTime`) in `Session.from_dict`.
- Updates `GitHubRepoContext` to gracefully handle `startingBranch`.
- Enhances `create_session` method in `JulesClient` to accept `require_plan_approval`, `source_context`, and `source`.
- Includes SDK examples (`examples/getting_started.py` and `examples/plan_review.py`) demonstrating standard session operations and polling.

---
*PR created automatically by Jules for task [10071375070521277132](https://jules.google.com/task/10071375070521277132) started by @davideast*