### PR TITLE
Fixes #105: [Fleet Execution] [Create Inspect Activity Snippet]

### DIFF
--- a/examples/inspect_activity.py
+++ b/examples/inspect_activity.py
@@ -1,0 +1,50 @@
+"""Inspecting detailed session activities using the Jules SDK.
+
+Usage:
+    export JULES_API_KEY=your-key
+    python examples/inspect_activity.py
+"""
+from jules import JulesClient
+from jules.models import ActivityType
+
+def main() -> None:
+    with JulesClient() as client:
+        print("Finding a session to inspect...")
+        sessions = list(client.list_sessions())
+        if not sessions:
+            print("No sessions found. Try running getting_started.py first.")
+            return
+
+        session = sessions[0]
+        print(f"Inspecting activities for session: {session.name}")
+
+        activities = list(client.list_activities(session.name))
+        if not activities:
+            print("No activities found in this session.")
+            return
+
+        # Pick the first activity to inspect deeply
+        target_activity = activities[0]
+        print(f"\nFetching detailed activity: {target_activity.name}")
+
+        # In a real app, you might receive the activity name from a webhook
+        activity = client.get_activity(target_activity.name)
+
+        print(f"Type: {activity.type.value}")
+        print(f"Created: {activity.create_time}")
+        print(f"Originator: {activity.originator or 'Unknown'}")
+        print(f"Description: {activity.description or 'None'}")
+
+        # Demonstrate unpacking the type-specific details
+        print("\nActivity Details:")
+        if activity.type == ActivityType.AGENT_MESSAGED:
+            message = activity.details.get("message", {})
+            print(f"Agent said: {message.get('text', 'No text')}")
+        elif activity.type == ActivityType.USER_MESSAGED:
+            message = activity.details.get("message", {})
+            print(f"User said: {message.get('text', 'No text')}")
+        else:
+            print(f"Raw details: {activity.details}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #105

Creates a python code snippet showing how to inspect an activity using the SDK.
It covers:
- Retrieving sessions and their activities using `list_activities`.
- Finding a specific activity and using `get_activity` to retrieve detailed properties.
- Showing how to access type-specific nested fields within `activity.details` for `AGENT_MESSAGED` and `USER_MESSAGED`.

Note: The `src/jules/__init__.py` file was already updated in the base branch with `__all__ = ["JulesClient"]` from previous snippet PRs, so the strict mypy check on `JulesClient` implicit re-export is already fixed.

---
*PR created automatically by Jules for task [15030957422710793047](https://jules.google.com/task/15030957422710793047) started by @davideast*