### PR TITLE
Fixes #135: Update archive REST endpoints

### DIFF
--- a/src/jules/client.py
+++ b/src/jules/client.py
@@ -106,11 +106,11 @@ class JulesClient:
         self._raise_for_status(response)
 
     def archive_session(self, name: str) -> None:
-        response = self._client.post(f"/{name}:archiveSession")
+        response = self._client.post(f"/{name}:archive")
         self._raise_for_status(response)
 
     def unarchive_session(self, name: str) -> None:
-        response = self._client.post(f"/{name}:unarchiveSession")
+        response = self._client.post(f"/{name}:unarchive")
         self._raise_for_status(response)
 
     def get_source(self, name: str) -> Source:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -126,11 +126,11 @@ def test_approve_plan(client, mock_api):
     client.approve_plan("sessions/123")
 
 def test_archive_session(client, mock_api):
-    mock_api.post("/sessions/123:archiveSession").mock(return_value=Response(200, json={}))
+    mock_api.post("/sessions/123:archive").mock(return_value=Response(200, json={}))
     client.archive_session("sessions/123")
 
 def test_unarchive_session(client, mock_api):
-    mock_api.post("/sessions/123:unarchiveSession").mock(return_value=Response(200, json={}))
+    mock_api.post("/sessions/123:unarchive").mock(return_value=Response(200, json={}))
     client.unarchive_session("sessions/123")
 
 def test_get_source(client, mock_api):


### PR DESCRIPTION
Fixes #135

Updates the `archive_session` and `unarchive_session` methods in `JulesClient` to correctly use the `:archive` and `:unarchive` REST endpoints instead of `:archiveSession` and `:unarchiveSession` according to the API discovery document. Also updates related tests.

---
*PR created automatically by Jules for task [12530907473496275278](https://jules.google.com/task/12530907473496275278) started by @davideast*

---
⚠️ Closed by fleet-merge: batch conflict resolution dispatched (session 14283136588696148336).