### PR TITLE
Fixes #135, Fixes #137: Update archive and unarchive endpoints

### DIFF
--- a/src/jules/client.py
+++ b/src/jules/client.py
@@ -108,10 +108,10 @@ class JulesClient:
         response = self._request("POST", f"/{name}:approvePlan")
 
     def archive_session(self, name: str) -> None:
-        response = self._request("POST", f"/{name}:archiveSession")
+        response = self._request("POST", f"/{name}:archive")
 
     def unarchive_session(self, name: str) -> None:
-        response = self._request("POST", f"/{name}:unarchiveSession")
+        response = self._request("POST", f"/{name}:unarchive")
 
     def get_source(self, name: str) -> Source:
         response = self._request("GET", f"/{name}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -126,11 +126,11 @@ def test_approve_plan(client, mock_api):
     client.approve_plan("sessions/123")
 
 def test_archive_session(client, mock_api):
-    mock_api.post("/sessions/123:archiveSession").mock(return_value=Response(200, json={}))
+    mock_api.post("/sessions/123:archive").mock(return_value=Response(200, json={}))
     client.archive_session("sessions/123")
 
 def test_unarchive_session(client, mock_api):
-    mock_api.post("/sessions/123:unarchiveSession").mock(return_value=Response(200, json={}))
+    mock_api.post("/sessions/123:unarchive").mock(return_value=Response(200, json={}))
     client.unarchive_session("sessions/123")
 
 def test_get_source(client, mock_api):


### PR DESCRIPTION
Updates the `archive_session` and `unarchive_session` methods in `JulesClient` to correctly use the `:archive` and `:unarchive` REST endpoints instead of `:archiveSession` and `:unarchiveSession` according to the API discovery document. 

This PR resolves conflicts and incorporates changes compatible with recent base branch updates (using `self._request` instead of `self._client.post`). Also updates related tests.

Fixes #135
Fixes #137

---
*PR created automatically by Jules for task [14283136588696148336](https://jules.google.com/task/14283136588696148336) started by @davideast*