### PR TITLE
Fixes #118: Update GitHubRepoContext data model

### DIFF
--- a/src/jules/models.py
+++ b/src/jules/models.py
@@ -30,20 +30,16 @@ class ActivityType(str, Enum):
 
 @dataclass
 class GitHubRepoContext:
-    github_repo: Optional['GitHubRepo'] = None
     starting_branch: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "GitHubRepoContext":
         return cls(
-            github_repo=GitHubRepo.from_dict(data["githubRepo"]) if "githubRepo" in data else None,
             starting_branch=data.get("startingBranch"),
         )
 
     def to_dict(self) -> Dict[str, Any]:
         result: Dict[str, Any] = {}
-        if self.github_repo:
-            result["githubRepo"] = self.github_repo.to_dict()
         if self.starting_branch:
             result["startingBranch"] = self.starting_branch
         return result

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,15 +12,7 @@ def test_session_from_dict():
         "requirePlanApproval": True,
         "sourceContext": {
             "source": "sources/1",
-            "githubRepoContext": {
-                "githubRepo": {
-                    "owner": "test",
-                    "repo": "repo",
-                    "isPrivate": True,
-                    "defaultBranch": {"displayName": "main"},
-                    "branches": [{"displayName": "main"}]
-                }
-            },
+            "githubRepoContext": {"startingBranch": "main"},
             "workingBranch": "main",
             "environmentVariablesEnabled": True
         }
@@ -35,7 +27,7 @@ def test_session_from_dict():
     assert session.source_context is not None
     assert session.source_context.source == "sources/1"
     assert session.source_context.github_repo_context is not None
-    assert session.source_context.github_repo_context.github_repo.owner == "test"
+    assert session.source_context.github_repo_context.starting_branch == "main"
     assert session.source_context.working_branch == "main"
     assert session.source_context.environment_variables_enabled is True
 
@@ -207,13 +199,7 @@ def test_source_context_to_dict():
     sc = SourceContext(
         source="sources/1",
         github_repo_context=GitHubRepoContext(
-            github_repo=GitHubRepo(
-                owner="test",
-                repo="repo",
-                is_private=True,
-                default_branch=GitHubBranch("main"),
-                branches=[]
-            )
+            starting_branch="main"
         ),
         working_branch="main",
         environment_variables_enabled=True
@@ -222,7 +208,7 @@ def test_source_context_to_dict():
     assert d["source"] == "sources/1"
     assert d["workingBranch"] == "main"
     assert d["environmentVariablesEnabled"] is True
-    assert d["githubRepoContext"]["githubRepo"]["owner"] == "test"
+    assert d["githubRepoContext"]["startingBranch"] == "main"
 
 def test_activity_unknown_type():
     data = {
@@ -286,6 +272,11 @@ def test_session_output_change_set():
     d = so.to_dict()
     assert d["changeSet"]["source"] == "source1"
 
-def test_github_repo_context_starting_branch():
-    context = GitHubRepoContext(starting_branch="feature-branch")
-    assert context.to_dict()["startingBranch"] == "feature-branch"
+def test_github_repo_context_serialization():
+    context = GitHubRepoContext(starting_branch="main")
+    assert context.to_dict() == {"startingBranch": "main"}
+
+def test_github_repo_context_deserialization():
+    context = GitHubRepoContext.from_dict({"startingBranch": "main"})
+    assert context.starting_branch == "main"
+    assert not hasattr(context, "github_repo") or context.github_repo is None


### PR DESCRIPTION
Fixes #118

Update GitHubRepoContext model in jules-sdk to match the API Discovery document which does not include a nested githubRepo object, avoiding 400 Invalid Argument errors.
- Removed `github_repo` property from `GitHubRepoContext`.
- Updated `to_dict` and `from_dict` methods.
- Updated related tests to match new structure.

---
*PR created automatically by Jules for task [17228068288816869704](https://jules.google.com/task/17228068288816869704) started by @davideast*