### PR TITLE
Fixes #201: Restore 100% Test Coverage for Python SDK (client.plan)

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -217,3 +217,12 @@ def test_create_session_with_automation_mode(client, mock_api):
     mock_api.post("/sessions").mock(return_value=Response(200, json={"name": "sessions/123", "state": "PLANNING", "createTime": "t1", "updateTime": "t2"}))
     client.create_session("foo", automation_mode=AutomationMode.AUTO_CREATE_PR)
     assert mock_api.calls[-1].request.read().decode().find('"automationMode":"AUTO_CREATE_PR"') != -1
+
+def test_plan_none(client, mock_api):
+    mock_api.get("/sessions/123/activities").mock(return_value=Response(200, json={
+        "activities": [
+            {"name": "activities/1", "createTime": "2024-01-01", "agentMessaged": {"message": {"text": "hello"}}},
+        ]
+    }))
+    plan = client.plan("sessions/123")
+    assert plan is None


### PR DESCRIPTION
Fixes #201

Restored 100% test coverage for the Python SDK by adding a unit test for the `plan()` method when no `PLAN_GENERATED` activity is found.

Note: Encountered a bug in the SDK where `SessionState` Enum misses `CANCELLED` state and `examples/getting_started.py` gets 429 errors. Created issue #211 for this. Also encountered timeout errors in `examples/list_and_filter.py` and `examples/sources.py` and created issue #212 for this.

---
*PR created automatically by Jules for task [5179324368786511828](https://jules.google.com/task/5179324368786511828) started by @davideast*