### PR TITLE
Fixes #224: Fix invalid SessionState references in code snippets

### DIFF
--- a/examples/getting_started.py
+++ b/examples/getting_started.py
@@ -33,7 +33,7 @@ def main() -> None:
             current_session = client.get_session(session.name)
             print(f"Current state: {current_session.state.value}")
 
-            if current_session.state in (SessionState.COMPLETED, SessionState.FAILED, SessionState.CANCELLED):
+            if current_session.state in (SessionState.COMPLETED, SessionState.FAILED):
                 print(f"Session finished with state: {current_session.state.value}")
                 break
 

--- a/examples/list_and_filter.py
+++ b/examples/list_and_filter.py
@@ -17,7 +17,7 @@ def main() -> None:
         print("\nFetching past sessions...")
         active_sessions = []
         for session in client.list_sessions():
-            if session.state in (SessionState.CREATED, SessionState.RUNNING):
+            if session.state in (SessionState.QUEUED, SessionState.IN_PROGRESS):
                 active_sessions.append(session.name)
 
         print(f"Found {len(active_sessions)} active sessions.")


### PR DESCRIPTION
Fixes #224

This PR fixes invalid `SessionState` Enum references (`CREATED`, `RUNNING`, `CANCELLED`) within `examples/list_and_filter.py` and `examples/getting_started.py` to use correct members `QUEUED`, `IN_PROGRESS`, `COMPLETED`, and `FAILED` defined in `jules.models.SessionState`.

---
*PR created automatically by Jules for task [2104186217683930537](https://jules.google.com/task/2104186217683930537) started by @davideast*