### PR TITLE
Fixes #227: Document plan() Method in JulesClient Reference

### DIFF
--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -83,6 +83,15 @@ Lists all activities within a session using pagination.
     *   `JulesAPIError`: Raised with status code 404 if the session is not found, or 401 for bad authentication.
     *   `JulesError`: Raised for underlying network failures via `httpx.RequestError`.
 
+#### `plan(session_name: str) -> Optional[Plan]`
+
+Retrieves the generated execution plan for a given session by parsing its activities.
+*   **`session_name`** (`str`): The unique name/identifier of the session.
+*   **Returns** (`Optional[Plan]`): A `Plan` object if a `PLAN_GENERATED` activity is found, otherwise `None`.
+*   **Raises**:
+    *   `JulesAPIError`: Raised with status code 404 if the session is not found, or 401 for bad authentication.
+    *   `JulesError`: Raised for underlying network failures via `httpx.RequestError`.
+
 #### `approve_plan(name: str) -> None`
 
 Approves a plan, resuming session execution.


### PR DESCRIPTION
Fixes #227

This PR adds the missing reference documentation for the `plan(session_name: str) -> Optional[Plan]` method to `docs/reference/client.md`, accurately describing its parameters, return types, and possible exceptions as implemented in the `src/jules/client.py` module.

Also ran local verification links and pytest tests. Note: While running verification steps, discovered a network read timeout bug with `list_sources()` during pagination which was reported as fleet signal #229.

---
*PR created automatically by Jules for task [15366067495135184304](https://jules.google.com/task/15366067495135184304) started by @davideast*